### PR TITLE
added scenario for a logged in user visiting login page

### DIFF
--- a/features/already_signedin.feature
+++ b/features/already_signedin.feature
@@ -1,0 +1,17 @@
+Feature: User already signed in
+  As a signed in user
+  In order to avoid to login twice in the same session
+  I would like to see a "You are already signed in." message when I visit the login page
+
+  Background:
+    Given the following users exist
+      | name    | email              | password |
+      | visitor | visitor@email.com  | password |
+
+  Scenario: Reaching the sign in page when already logged in
+    Given I am on the login page
+    And I fill in "Email" with "visitor@email.com"
+    And I fill in "Password" with "password"
+    And I click button "Log in"
+    When I am on the login page
+    Then I should see "You are already signed in." message

--- a/features/step_definitions/already_signedin_steps.rb
+++ b/features/step_definitions/already_signedin_steps.rb
@@ -1,0 +1,7 @@
+Given(/^I am logged in as "([^"]*)"$/) do |name|
+  name
+end
+
+Then(/^I should see "([^"]*)" message$/) do |content|
+  expect(page).to have_content content
+end


### PR DESCRIPTION
When a logged in user tries to visit the login page during his current session a "You are already signed in." message is displayed in the page.
